### PR TITLE
Use cliutils now that we imported it

### DIFF
--- a/os_networksv2_python_novaclient_ext.py
+++ b/os_networksv2_python_novaclient_ext.py
@@ -39,7 +39,7 @@ class NetworkManager(base.ManagerWithFind):
         return self._create('/os-networksv2', body, 'network')
 
 
-@utils.arg('network_id', metavar='<network_id>', help='ID of network')
+@cliutils.arg('network_id', metavar='<network_id>', help='ID of network')
 def do_network(cs, args):
     """
     Show a network
@@ -56,21 +56,21 @@ def do_network_list(cs, args):
     utils.print_list(networks, ['ID', 'Label', 'CIDR'])
 
 
-@utils.arg('label', metavar='<network_label>',
-           help='Network label (ex. my_new_network)')
-@utils.arg('cidr', metavar='<cidr>',
-           help='IP block to allocate from (ex. 172.16.0.0/24 or '
-                '2001:DB8::/64)')
+@cliutils.arg('label', metavar='<network_label>',
+              help='Network label (ex. my_new_network)')
+@cliutils.arg('cidr', metavar='<cidr>',
+              help='IP block to allocate from (ex. 172.16.0.0/24 or '
+                   '2001:DB8::/64)')
 def do_network_create(cs, args):
     """
     Create a network
     """
     network = cs.os_networksv2_python_novaclient_ext.create(args.label,
-                                                           args.cidr)
+                                                            args.cidr)
     utils.print_dict(network._info)
 
 
-@utils.arg('network_id', metavar='<network_id>', help='ID of network')
+@cliutils.arg('network_id', metavar='<network_id>', help='ID of network')
 def do_network_delete(cs, args):
     """
     Delete a network


### PR DESCRIPTION
It looks like two of the commits that were merged essentially canceled
each other out. This commit uses cliutils.arg instead of utils.arg
since utils.arg was removed.